### PR TITLE
Generate isReady KVO even only once

### DIFF
--- a/PSOperations/Operation.swift
+++ b/PSOperations/Operation.swift
@@ -16,6 +16,8 @@ import Foundation
 */
 open class Operation: Foundation.Operation {
     
+    private var observerContext = 4321
+    
     /* The completionBlock property has unexpected behaviors such as executing twice and executing on unexpected threads. BlockObserver
      * executes in an expected manner.
      */
@@ -29,12 +31,7 @@ open class Operation: Foundation.Operation {
         }
     }
     
-    
     // use the KVO mechanism to indicate that changes to "state" affect other properties as well
-    class func keyPathsForValuesAffectingIsReady() -> Set<NSObject> {
-        return ["state" as NSObject, "cancelledState" as NSObject]
-    }
-    
     class func keyPathsForValuesAffectingIsExecuting() -> Set<NSObject> {
         return ["state" as NSObject]
     }
@@ -45,6 +42,15 @@ open class Operation: Foundation.Operation {
     
     class func keyPathsForValuesAffectingIsCancelled() -> Set<NSObject> {
         return ["cancelledState" as NSObject]
+    }
+    
+    public override init() {
+        super.init()
+        self.addObserver(self, forKeyPath: "isReady", context: &observerContext)
+    }
+    
+    deinit {
+        self.removeObserver(self, forKeyPath: "isReady", context: &observerContext)
     }
     
     // MARK: State Management
@@ -142,48 +148,49 @@ open class Operation: Foundation.Operation {
                 
                 assert(_state.canTransitionToState(newState, operationIsCancelled: isCancelled), "Performing invalid state transition.")
                 _state = newState
+                updateReadiness()
             }
             
             didChangeValue(forKey: "state")
         }
     }
     
-    // Here is where we extend our definition of "readiness".
-    override open var isReady: Bool {
-        
-        var _ready = false
-        
-        stateLock.withCriticalScope {
-            switch state {
-                
-            case .initialized:
-                // If the operation has been cancelled, "isReady" should return true
-                _ready = isCancelled
-                
-            case .pending:
-                // If the operation has been cancelled, "isReady" should return true
-                guard !isCancelled else {
-                    state = .ready
-                    _ready = true
-                    return
-                }
-                
-                // If super isReady, conditions can be evaluated
-                if super.isReady {
-                    evaluateConditions()
-                    _ready = state == .ready
-                }
-                
-            case .ready:
-                _ready = super.isReady || isCancelled
-                
-            default:
-                _ready = false
-            }
-            
+    open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        if context == &observerContext {
+            updateReadiness()
+        } else {
+            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
         }
-        
-        return _ready
+    }
+
+    private func updateReadiness() {
+        stateLock.withCriticalScope {
+            let cancelled = isCancelled
+            
+            if state == .pending {
+                if cancelled {
+                    state = .ready
+                } else if super.isReady {
+                    evaluateConditions()
+                }
+            }
+
+            // Generate KVO notitification only once when operation is really ready
+            let newReady = state >= .ready || (state == .initialized && cancelled)
+            if !_ready && newReady {
+                willChangeValue(forKey: "isReady")
+                _ready = true
+                didChangeValue(forKey: "isReady")
+            }
+        }
+    }
+    
+    private var _ready: Bool = false
+    
+    override open var isReady: Bool {
+        return stateLock.withCriticalScope {
+            return _ready && super.isReady
+        }
     }
     
     open var userInitiated: Bool {
@@ -214,6 +221,7 @@ open class Operation: Foundation.Operation {
         didSet {
             didChangeValue(forKey: "cancelledState")
             if _cancelled != oldValue && _cancelled == true {
+                updateReadiness()
                 
                 for observer in observers {
                     observer.operationDidCancel(self)


### PR DESCRIPTION
Problem was that “isReady” property change KVO event was generated on every “state” property change, but in most of cases state-change doesn’t mean isReady-change. After every isReady KVO event, isReady property is read by NSOperations runtime. Since state-change (and as a result isReady KVO event) may happen and happens in multiple threads, isReady-getter is called from multiple threads too. The problem happens when isReady is called from multiple threads around the same time: the first call return False, but the second one returns True. Since there are two threads, first call can be actually finished after second one. In this case NSOperations runtime receivce isReady state value in the order like [false, false… false, true, false]. In this situation operations is actually ready, but it is not executed by queue (looks like because last isReady state was False).

To fix the described problem idea is to stop bombing with KVO events. Actually during NSOperation life isReady is changed only once from false -> true. So ideally is to have only one KVO event when operations is really ready.